### PR TITLE
Scroll context cleanup and removal of unnecessary out-param from scroll()

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -107,7 +107,14 @@ jobs:
             - name: 'Setup Elasticsearch'
               env:
                   ELASTICSEARCH_VERSION: ${{ matrix.elasticsearch }}
-              run: docker compose up --detach --wait ; curl -XGET 'http://localhost:'"$ELASTICSEARCH_PORT"
+              run: |
+                  if ! docker compose up --detach --wait; then
+                      echo '::group::Elasticsearch container logs'
+                      docker compose logs elasticsearch
+                      echo '::endgroup::'
+                      exit 1
+                  fi
+                  curl -XGET 'http://localhost:'"$ELASTICSEARCH_PORT"
 
             - name: 'Run phpunit tests'
               run: |

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/dotenv": "^5.4 || ^6.4",
 
         "doctrine/orm": "^2.6.3",
-        "doctrine/annotations": "^1.2",
+        "doctrine/annotations": "^1.14 || ^2.0",
         "knplabs/knp-paginator-bundle": "^4.0 || ^5.0",
         "monolog/monolog": "^2.0|^3.0",
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,14 @@ services:
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
+      # -XX:-UseContainerSupport works around JDK-8287073: the JDKs bundled in older ES images (8.0, 8.1)
+      # crash with an NPE in CgroupV2Subsystem on hosts with a cgroup v2 layout they cannot parse, such as
+      # current GitHub Actions runners (https://github.com/actions/runner-images/issues/13684).
+      # It is set via _JAVA_OPTIONS, as that is picked up by every JVM the image starts - including the
+      # options-parsing launcher and the CLI tools, not just the server (unlike ES_JAVA_OPTS, and unlike
+      # JAVA_TOOL_OPTIONS, which the elasticsearch-env script explicitly unsets). Disabling JVM container awareness
+      # is safe here, as the heap size is set explicitly.
+      - "_JAVA_OPTIONS=-XX:-UseContainerSupport"
       - "ES_JAVA_OPTS=-Xms${ELASTICSEARCH_JAVA_MEM:-2048m} -Xmx${ELASTICSEARCH_JAVA_MEM:-2048m}"
       - cluster.name=sfes
       - node.name=sfes1

--- a/src/Exception/ScrollHitsUnavailableException.php
+++ b/src/Exception/ScrollHitsUnavailableException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Sineflow\ElasticsearchBundle\Exception;
-
-class ScrollHitsUnavailableException extends \RuntimeException implements ElasticsearchBundleException
-{
-}

--- a/src/Finder/Adapter/ScrollAdapter.php
+++ b/src/Finder/Adapter/ScrollAdapter.php
@@ -4,7 +4,6 @@ namespace Sineflow\ElasticsearchBundle\Finder\Adapter;
 
 use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Elastic\Elasticsearch\Exception\ServerResponseException;
-use Sineflow\ElasticsearchBundle\Exception\ScrollHitsUnavailableException;
 use Sineflow\ElasticsearchBundle\Finder\Finder;
 use Sineflow\ElasticsearchBundle\Result\DocumentIterator;
 
@@ -12,7 +11,7 @@ class ScrollAdapter
 {
     private string $scrollId;
     private readonly int $resultsType;
-    private ?int $totalHits = null;
+    private readonly int $totalHits;
 
     /**
      * When a search query with a 'scroll' param is performed, not only the scroll id is returned, but also the
@@ -33,34 +32,39 @@ class ScrollAdapter
     ) {
         $this->scrollId = $rawResults['_scroll_id'];
         $this->initialResults = $rawResults;
+        $this->totalHits = $rawResults['hits']['total']['value'];
         // Make sure we don't get an adapter returned again when we recursively execute the paginated find()
         $this->resultsType = $resultsType & ~Finder::BITMASK_RESULT_ADAPTERS;
     }
 
     /**
-     * Returns results from a scroll request
+     * Returns the next batch of results from a scroll request, or false when there are no more.
+     * Once false is returned, the scroll context is cleared and this method must not be called again -
+     * doing so would attempt a scroll request with a scroll id that no longer exists on the cluster
+     * and result in a ClientResponseException, unless the search matched no documents at all.
      *
      * @throws ClientResponseException
      * @throws ServerResponseException
      */
     public function getNextScrollResults(): array|DocumentIterator|false
     {
+        // The search matched no documents, so no scroll context is held on the cluster -
+        // Finder::find() has already cleared it
+        if (0 === $this->totalHits) {
+            return false;
+        }
+
         // If this is the first call to this method, return the cached initial results from the search request
         if (null !== $this->initialResults) {
-            if (\count($this->initialResults['hits']['hits']) > 0) {
-                $results = $this->finder->parseResult($this->initialResults, $this->resultsType, $this->documentClasses);
-            } else {
-                $results = false;
-            }
+            $results = $this->finder->parseResult($this->initialResults, $this->resultsType, $this->documentClasses);
             $this->initialResults = null;
         } else {
-            // Execute a scroll request
+            // Execute a scroll request, which also clears the scroll context when there are no more results
             $results = $this->finder->scroll(
                 $this->documentClasses,
                 $this->scrollId,
                 $this->scrollTime,
-                $this->resultsType,
-                $this->totalHits
+                $this->resultsType
             );
         }
 
@@ -68,17 +72,10 @@ class ScrollAdapter
     }
 
     /**
-     * Returns the total hits by the query, which the scroll is for
-     * or throws an exception, if no scrolls have been retrieved yet
-     *
-     * @throws ScrollHitsUnavailableException
+     * Returns the total hits matched by the query, which the scroll is for
      */
     public function getTotalHits(): int
     {
-        if (null === $this->totalHits) {
-            throw new ScrollHitsUnavailableException('You must call getNextScrollResults() at least once, before you can get the total hits');
-        }
-
         return $this->totalHits;
     }
 }

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -117,9 +117,16 @@ class Finder
                 'body'   => ['sort' => ['_doc']],
             ], $params);
 
-            $rawResults = $client->search($params);
+            $rawResults = $client->search($params)->asArray();
+            $totalHits = $rawResults['hits']['total']['value'];
 
-            return new ScrollAdapter($this, $documentClasses, $rawResults->asArray(), $resultsType, $params['scroll']);
+            // The search matched no documents, so no scroll request will follow that would clear the scroll
+            // context - clear it right away, instead of letting it occupy a slot on the cluster until it expires
+            if (0 === $totalHits) {
+                $this->clearScroll($documentClasses, $rawResults['_scroll_id']);
+            }
+
+            return new ScrollAdapter($this, $documentClasses, $rawResults, $resultsType, $params['scroll']);
         }
 
         $raw = $client->search($params);
@@ -133,18 +140,17 @@ class Finder
      * Executes a scroll request, based on a given scrollId.
      * Returns false when there are no more hits
      *
-     * @param array    $documentClasses The ES entities involved in the scrolled search
-     * @param string   $scrollId        (in/out param) The Scroll ID as returned from the Scan request or a previous Scroll request
-     * @param string   $scrollTime      The time to keep the scroll window open
-     * @param int      $resultsType     Bitmask value determining how the results are returned
-     * @param int|null $totalHits       (out param) The total hits of the query response
+     * @param array  $documentClasses The ES entities involved in the scrolled search
+     * @param string $scrollId        (in/out param) The Scroll ID as returned from the Scan request or a previous Scroll request
+     * @param string $scrollTime      The time to keep the scroll window open
+     * @param int    $resultsType     Bitmask value determining how the results are returned
      *
      * @throws NoNodeAvailableException     if all the hosts are offline
      * @throws ClientResponseException      if the status code of response is 4xx
      * @throws ServerResponseException      if the status code of response is 5xx
      * @throws InvalidIndexManagerException
      */
-    public function scroll(array $documentClasses, string &$scrollId, string $scrollTime = self::SCROLL_TIME, int $resultsType = self::RESULTS_OBJECT, ?int &$totalHits = null): array|bool|DocumentIterator
+    public function scroll(array $documentClasses, string &$scrollId, string $scrollTime = self::SCROLL_TIME, int $resultsType = self::RESULTS_OBJECT): array|bool|DocumentIterator
     {
         $client = $this->getConnection($documentClasses)->getClient();
 
@@ -159,20 +165,35 @@ class Finder
 
         $scrollId = $raw['_scroll_id'];
 
-        $totalHits = $raw['hits']['total']['value'];
-
         // If no results were returned, clear the scroll
         if (0 === \count($raw['hits']['hits'])) {
-            $client->clearScroll([
-                'body' => [
-                    'scroll_id' => $scrollId,
-                ],
-            ]);
+            $this->clearScroll($documentClasses, $scrollId);
 
             return false;
         }
 
         return $this->parseResult($raw->asArray(), $resultsType, $documentClasses);
+    }
+
+    /**
+     * Explicitly clears a scroll context, freeing the resources it holds on the cluster.
+     * Without this, the context would remain open until its scroll time expires.
+     *
+     * @param string[] $documentClasses The ES entities involved in the scrolled search
+     * @param string   $scrollId        The Scroll ID identifying the scroll context to clear
+     *
+     * @throws NoNodeAvailableException     if all the hosts are offline
+     * @throws ClientResponseException      if the status code of response is 4xx
+     * @throws ServerResponseException      if the status code of response is 5xx
+     * @throws InvalidIndexManagerException
+     */
+    private function clearScroll(array $documentClasses, string $scrollId): void
+    {
+        $this->getConnection($documentClasses)->getClient()->clearScroll([
+            'body' => [
+                'scroll_id' => $scrollId,
+            ],
+        ]);
     }
 
     /**
@@ -315,7 +336,7 @@ class Finder
     }
 
     /**
-     * Verify that all types are in indices using the same connection object and return that object
+     * Verify that all searched indices are using the same connection object and return that object
      */
     private function getConnection(array $documentClasses): ?ConnectionManager
     {
@@ -324,7 +345,7 @@ class Finder
             $indexManagerName = $this->documentMetadataCollector->getDocumentClassIndex($documentClass);
             $indexManager = $this->indexManagerRegistry->get($indexManagerName);
             if (null !== $connection && $indexManager->getConnection()->getConnectionName() !== $connection->getConnectionName()) {
-                throw new \InvalidArgumentException('All searched types must be in indices within the same connection');
+                throw new \InvalidArgumentException('All searched indices must use the same connection');
             }
             $connection = $indexManager->getConnection();
         }

--- a/src/Mapping/DocumentParser.php
+++ b/src/Mapping/DocumentParser.php
@@ -2,7 +2,6 @@
 
 namespace Sineflow\ElasticsearchBundle\Mapping;
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\Reader;
 use Sineflow\ElasticsearchBundle\Annotation\DocObject;
 use Sineflow\ElasticsearchBundle\Annotation\Document;
@@ -45,7 +44,6 @@ class DocumentParser
         private readonly string $languageSeparator,
         private readonly array $languages = [],
     ) {
-        $this->registerAnnotations();
     }
 
     /**
@@ -184,24 +182,6 @@ class DocumentParser
     private function getPropertyAnnotationData(\ReflectionProperty $property): ?Property
     {
         return $this->reader->getPropertyAnnotation($property, Property::class);
-    }
-
-    /**
-     * Registers annotations to registry so that it could be used by reader.
-     */
-    private function registerAnnotations(): void
-    {
-        $annotations = [
-            'Document',
-            'Property',
-            'DocObject',
-            'Id',
-            'Score',
-        ];
-
-        foreach ($annotations as $annotation) {
-            AnnotationRegistry::registerFile(__DIR__."/../Annotation/{$annotation}.php");
-        }
     }
 
     /**

--- a/tests/Functional/Finder/Adapter/ScrollAdapterTest.php
+++ b/tests/Functional/Finder/Adapter/ScrollAdapterTest.php
@@ -2,6 +2,9 @@
 
 namespace Sineflow\ElasticsearchBundle\Tests\Functional\Finder\Adapter;
 
+use Elastic\Elasticsearch\Exception\ClientResponseException;
+use Jchook\AssertThrows\AssertThrows;
+use PHPUnit\Framework\Attributes\Group;
 use Sineflow\ElasticsearchBundle\Document\Repository\Repository;
 use Sineflow\ElasticsearchBundle\Finder\Adapter\ScrollAdapter;
 use Sineflow\ElasticsearchBundle\Finder\Finder;
@@ -10,6 +13,8 @@ use Sineflow\ElasticsearchBundle\Tests\App\Fixture\Acme\BarBundle\Document\Produ
 
 class ScrollAdapterTest extends AbstractElasticsearchTestCase
 {
+    use AssertThrows;
+
     /**
      * {@inheritdoc}
      */
@@ -129,5 +134,83 @@ class ScrollAdapterTest extends AbstractElasticsearchTestCase
         $this->assertSame(6, $i, 'Total matching documents iterated');
         $this->assertSame(6, $scrollAdapter->getTotalHits(), 'Total hits returned by scroll');
         $this->assertSame(2, $scrolls, 'Total number of scrolls');
+    }
+
+    public function testScrollContextIsClearedWhenSearchMatchesNoDocuments(): void
+    {
+        /** @var Repository $repo */
+        $repo = $this->getIndexManager('bar')->getRepository();
+
+        $openContextsBefore = $this->getOpenScrollContextsCount();
+
+        /** @var ScrollAdapter $scrollAdapter */
+        $scrollAdapter = $repo->find(
+            ['query' => ['term' => ['title' => ['value' => 'nosuchtitle']]]],
+            Finder::RESULTS_OBJECT | Finder::ADAPTER_SCROLL,
+            ['size' => 2]
+        );
+
+        $this->assertSame($openContextsBefore, $this->getOpenScrollContextsCount(), 'The scroll context is cleared right away when the search matches no documents');
+        $this->assertSame(0, $scrollAdapter->getTotalHits());
+
+        $this->assertFalse($scrollAdapter->getNextScrollResults());
+        $this->assertFalse($scrollAdapter->getNextScrollResults(), 'When the search matched no documents, repeated calls safely keep returning false, as no scroll request is ever made');
+    }
+
+    public function testScrollContextIsClearedWhenResultsAreExhausted(): void
+    {
+        /** @var Repository $repo */
+        $repo = $this->getIndexManager('bar')->getRepository();
+
+        $openContextsBefore = $this->getOpenScrollContextsCount();
+
+        /** @var ScrollAdapter $scrollAdapter */
+        $scrollAdapter = $repo->find(
+            ['query' => ['term' => ['title' => ['value' => 'product']]]],
+            Finder::RESULTS_OBJECT | Finder::ADAPTER_SCROLL,
+            ['size' => 2]
+        );
+
+        while (false !== $scrollAdapter->getNextScrollResults()) {
+        }
+
+        $this->assertSame($openContextsBefore, $this->getOpenScrollContextsCount(), 'The scroll context is cleared once all results have been retrieved');
+
+        // Once false has been returned, the scroll context is cleared and the method must not be called again -
+        // doing so attempts a scroll request with a scroll id that no longer exists on the cluster
+        $this->assertThrows(ClientResponseException::class, static function () use ($scrollAdapter): void {
+            $scrollAdapter->getNextScrollResults();
+        });
+    }
+
+    #[Group('AI')]
+    public function testGetTotalHitsIsAvailableBeforeAnyResultsAreRetrieved(): void
+    {
+        /** @var Repository $repo */
+        $repo = $this->getIndexManager('bar')->getRepository();
+
+        /** @var ScrollAdapter $scrollAdapter */
+        $scrollAdapter = $repo->find(
+            ['query' => ['term' => ['title' => ['value' => 'product']]]],
+            Finder::RESULTS_OBJECT | Finder::ADAPTER_SCROLL,
+            ['size' => 2],
+            $totalHits
+        );
+
+        $this->assertSame(6, $scrollAdapter->getTotalHits(), 'The total hits are available right away, before any results have been retrieved');
+        $this->assertSame(6, $totalHits, 'The total hits are also returned through the out param of find()');
+    }
+
+    /**
+     * Returns the total number of scroll contexts currently open on the cluster
+     */
+    private function getOpenScrollContextsCount(): int
+    {
+        $stats = $this->getIndexManager('bar', false)->getConnection()->getClient()->nodes()->stats([
+            'metric'       => 'indices',
+            'index_metric' => 'search',
+        ])->asArray();
+
+        return \array_sum(\array_map(static fn (array $node): int => $node['indices']['search']['open_contexts'], $stats['nodes']));
     }
 }


### PR DESCRIPTION
- Make sure scroll context after a query with no results is closed straight away and not left occupying a slot (counting against search.max_open_scroll_context)
- ScrollAdapter::getTotalHits() is now always available and exact
- Finder::find() now populates its $totalHits out-param on the ADAPTER_SCROLL path

BC breaks
- [BC] Removed the $totalHits out-param from Finder::scroll(). It existed only to feed the ScrollAdapter, which now gets the total from the initial response; the total is also available via find()'s out-param.
- [BC] Removed ScrollHitsUnavailableException - getTotalHits() no longer throws.
